### PR TITLE
skipping expensive AST build for code without requires

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,16 @@
 var estraverse = require('estraverse');
 var esprima = require('esprima-six');
 var esrefactor = require('esrefactor');
+
+var requireRegexp = /require.*\(.*['"]/m;
 function testParse (code) {
     try{
          return esprima.parse(code,{range:true});
     }catch(e){}
 }
 function rename(code, tokenTo, tokenFrom) {
+    if (!requireRegexp.test(code)) return code;
+
     tokenTo = tokenTo || '_dereq_';
     tokenFrom = tokenFrom || 'require';
     if(tokenTo.length !== tokenFrom.length){
@@ -18,7 +22,7 @@ function rename(code, tokenTo, tokenFrom) {
     if(!ast){
         return code;
     }
-    var ctx = new esrefactor.Context(inCode);;
+    var ctx = new esrefactor.Context(inCode);
    
     estraverse.traverse(ast,{
         enter:function(node, parent) {

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ npm install derequire
 
 ```javascript
 var derequire = require('derequire');
-var transformedCode = derequire(code [,tokenTo='_dereq_', tokenFrom='require');
+var transformedCode = derequire(code, /*tokenTo=*/'_dereq_', /*tokenFrom=*/'require');
 ```
 
 takes a string of code and replaces all instances of the identifier `tokenFrom` (default 'require') and replaces them with tokenTo (default '\_dereq\_') but only if they are functional arguments and subsequent uses of said argument, then returnes the code.

--- a/test/test.js
+++ b/test/test.js
@@ -23,9 +23,17 @@ describe('derequire', function(){
     var exampleText = 'var x=function(require,module,exports){var process=require("__browserify_process");var requireText = "require";}//lala';
     derequire(exampleText).should.equal('var x=function(_dereq_,module,exports){var process=_dereq_("__browserify_process");var requireText = "require";}//lala');
   });
+  it('should work with whitespace inside require statement', function(){
+    var exampleText = 'var x=function(require,module,exports){var process=require(  "__browserify_process"   )}';
+    derequire(exampleText).should.equal('var x=function(_dereq_,module,exports){var process=_dereq_(  "__browserify_process"   )}');
+  });
+  it('should work with single quoted requires', function(){
+    var exampleText = 'var x=function(require,module,exports){var process=require(\'__browserify_process\')}';
+    derequire(exampleText).should.equal('var x=function(_dereq_,module,exports){var process=_dereq_(\'__browserify_process\')}');
+  });
   it('should throw an error if you try to change things of different sizes', function(){
     should.throw(function(){
-      derequire('lalalalla', 'la');
+      derequire('require("x")', 'lalalalla', 'la');
     });
   });
   it("should return the code back if it can't parse it", function(){


### PR DESCRIPTION
- building AST is expensive so returning early if no require statement is found saves time
- fixed the throw test that did not pass any code (missing arg) and made it include require to not return early
- added more tests to ensure that whitespace around require and single quoted requires works
- fixed minor bug in readme
