### PR TITLE
Remove esprima-six in favour for esprima

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var estraverse = require('estraverse');
-var esprima = require('esprima-six');
+var esprima = require('esprima');
 var esrefactor = require('esrefactor');
 
 var requireRegexp = /require.*\(.*['"]/m;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/calvinmetcalf/derequire",
   "dependencies": {
     "estraverse": "~1.5.0",
-    "esprima-six": "~0.0.3",
+    "esprima": "~1.0.4",
     "esrefactor": "~0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The former still has a lot of issues parsing, and will break on bundling modules such as `escodegen`.

Downgrading to esprima fixes this issue, at the expense of ES6 support. The same has been done for the following modules:
- astw (http://git.io/3qnK6A)
- detective (http://git.io/GeWevg)
- syntax-error (http://git.io/j7gJZg)

This should also probably be a major version bump to 1.0.0 too.

Thanks! :)
