### PR TITLE
Use esprima-fb to parse es6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var estraverse = require('estraverse');
-var esprima = require('esprima');
+var esprima = require('esprima-fb');
 var esrefactor = require('esrefactor');
 
 var requireRegexp = /require.*\(.*['"]/m;
@@ -23,10 +23,10 @@ function rename(code, tokenTo, tokenFrom) {
         return code;
     }
     var ctx = new esrefactor.Context(inCode);
-   
+
     estraverse.traverse(ast,{
         enter:function(node, parent) {
-            var test = 
+            var test =
             parent &&
             (parent.type === 'FunctionDeclaration' || parent.type === 'FunctionExpression') &&
             node.name === tokenFrom &&
@@ -34,7 +34,7 @@ function rename(code, tokenTo, tokenFrom) {
             if(test){
                 ctx._code = ctx.rename(ctx.identify(node.range[0]), tokenTo);
             }
-        } 
+        }
     });
     return ctx._code.slice(12, -3);
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "homepage": "https://github.com/calvinmetcalf/derequire",
   "dependencies": {
     "estraverse": "~1.5.0",
-    "esprima": "~1.0.4",
-    "esrefactor": "~0.1.0"
+    "esrefactor": "~0.1.0",
+    "esprima-fb": "^3001.1.0-dev-harmony-fb"
   },
   "devDependencies": {
     "chai": "~1.8.1",


### PR DESCRIPTION
esprima-fb is used over a yeat in production at Facebook in their es6-to-es5
code transforms so I think it could be considered robust.
