### PR TITLE
Speedup

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,8 @@ function rename(code, tokenTo, tokenFrom) {
   var tokenNames = tokens.map(function (item) {
     return item.from;
   });
-  var ctx = new esrefactor.Context(inCode);
+  var ctx = new esrefactor.Context(ast);
+  ctx._code = inCode;
 
   estraverse.traverse(ast,{
     enter:function(node, parent) {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "homepage": "https://github.com/calvinmetcalf/derequire",
   "dependencies": {
     "concat-stream": "^1.4.6",
-    "esprima-fb": "^3001.1.0-dev-harmony-fb",
+    "esprima-fb": "^10001.1.0-dev-harmony-fb",
     "esrefactor": "~0.1.0",
-    "estraverse": "~1.5.0",
+    "estraverse": "~1.9.1",
     "yargs": "^1.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This diff dramatically increases the speed of derequire by: (1) eliminating an unnecessary ast parse and (2) updating to newer versions of  `esprima-fb` and `estraverse`.

By passing the ast that was created earlier by `esprima-fb` directly to `esrefactor`, you can save an extra ast parse. It's necessary to assign the original source to the private var `_code` because of how [`setCode`](https://github.com/ariya/esrefactor/blob/d6be48b3443fd19415a9753c5d41222e2c49f958/lib/esrefactor.js#L53-L67) works. But that shouldn't be a problem because `derequire` already depends on that to [return the modified source](https://github.com/calvinmetcalf/derequire/blob/78e4bd8158de512644036bafbc7bde278867b7e9/index.js#L71)