### PR TITLE
Call toString on the result of derequire

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -30,5 +30,5 @@ if (file && file !== '-') {
 }
 
 input.pipe(concat(function(buf) {
-  console.log(derequire(buf, argv.t, argv.f));
+  process.stdout.write(derequire(buf, argv.t, argv.f));
 }));


### PR DESCRIPTION
This is because derequire returns an instance of Buffer.

This causes issues when doing something like `cat file | derequire > otherfile` 