### PR TITLE
shorthand properties 

### DIFF
--- a/test/es6.js
+++ b/test/es6.js
@@ -1,6 +1,6 @@
 function outer(require=()=>{}) {
   require('foo');
-  const opts = {require: require};
+  const opts = {require};
   opts.require('lala');
 }
 function other(opts) {


### PR DESCRIPTION

```js
const opts = {require};
opts.require('lala');
```

will turn into 

```js
const opts = {__dereq__};
opts.require('lala');
```

and cause an error, we want it to turn into

```js
const opts = {require:__dereq__};
opts.require('lala');
```
though can't at the moment